### PR TITLE
Add service landing pages and update navigation

### DIFF
--- a/src/data/config.ts
+++ b/src/data/config.ts
@@ -1,6 +1,6 @@
 export const siteConfig = {
   companyName: 'Cefem – Centro Familiar de Especialidades Médicas',
-  siteUrl: 'https://cefem.ar',
+  siteUrl: 'https://www.cefem.ar',
   Socials: {
       xSocial: '',
       Github: '',

--- a/src/data/menu.ts
+++ b/src/data/menu.ts
@@ -12,12 +12,12 @@ export const headerMenu: MenuItem[] = [
 ];
 
 export const footerMenu: MenuItem[] = [
-  { name: 'Ecografías en Las Rosas', link: '/especialidades' },
-  { name: 'Pediatría', link: '/especialidades' },
+  { name: 'Ecografías en Las Rosas', link: '/ecografias-las-rosas/' },
+  { name: 'Pediatría', link: '/pediatria/' },
   { name: 'Traumatología', link: '/especialidades' },
-  { name: 'Ginecología y Obstetricia', link: '/especialidades' },
+  { name: 'Ginecología y Obstetricia', link: '/ginecologia/' },
   { name: 'Urología', link: '/especialidades' },
-  { name: 'Nutrición', link: '/especialidades' },
+  { name: 'Nutrición', link: '/nutricion/' },
   { name: 'Depilación', link: '/especialidades' },
   { name: 'Solicitar Turno por WhatsApp', link: 'https://wa.me/5493471341461' },
 ];

--- a/src/pages/components/index.astro
+++ b/src/pages/components/index.astro
@@ -96,7 +96,7 @@ const styleGuideSection = {
     buttons: [
         {
             text: "Conocé el Centro",
-            link: "/centro",
+            link: "/contact",
             variant: "primary" as const
         }
     ]
@@ -115,7 +115,7 @@ const sideBySideStats = {
         description: 'Nuestro equipo médico está formado por especialistas altamente capacitados.',
         button: {
             text: 'Conocé al equipo',
-            link: '/equipo',
+            link: '/especialidades',
             variant: 'primary' as const
         }
     }

--- a/src/pages/ecografias-las-rosas/index.astro
+++ b/src/pages/ecografias-las-rosas/index.astro
@@ -1,0 +1,146 @@
+---
+import Layout from "@layouts/Layout.astro";
+import InnerHero from "@components/sections/InnerHero.astro";
+import CtaBanner from "@components/sections/CtaBanner.astro";
+import Faqs from "@components/sections/Faqs.astro";
+import type { FaqItem } from "@data/faqs";
+import heroImage from "../../assets/images/blog-hero-2.jpg";
+
+const heroContent = {
+    title: "Ecografías en Las Rosas – CeFEM",
+    description: "Estudios ecográficos generales, obstétricos, doppler y ginecológicos con médicos especialistas y equipamiento digital de alta resolución.",
+    imageAlt: "Equipo médico realizando una ecografía en CeFEM",
+    backgroundImage: heroImage,
+    overlayOpacity: 0.35,
+};
+
+const examSections = [
+    {
+        title: "Ecografías generales",
+        description: "Evaluamos abdomen, partes blandas, tiroides, riñones y estudios vasculares periféricos para un diagnóstico preciso en menos tiempo.",
+    },
+    {
+        title: "Ecografías obstétricas",
+        description: "Control integral del embarazo: ecografías del primer trimestre, morfológicas, doppler obstétrico y seguimiento del crecimiento fetal.",
+    },
+    {
+        title: "Ecografía ginecológica",
+        description: "Valoramos útero, ovarios y piso pélvico para acompañar diagnósticos y tratamientos ginecológicos en articulación con nuestras especialistas.",
+    },
+    {
+        title: "Ecografías doppler",
+        description: "Estudios doppler color y pulsado para valorar flujo sanguíneo en embarazadas, arterias y venas, permitiendo detectar alteraciones tempranas.",
+    },
+];
+
+const preparationTips = [
+    "Presentate 10 minutos antes del turno para coordinar la preparación junto al equipo.",
+    "Llevá órdenes médicas, estudios previos y credencial de la obra social si corresponde.",
+    "Para estudios abdominales se recomienda ayuno de 6 a 8 horas; para pelvis, beber 1 litro de agua una hora antes.",
+    "En ecografías obstétricas traé tus controles anteriores para comparar la evolución del embarazo.",
+];
+
+const differentiators = [
+    "Médicos especialistas en diagnóstico por imágenes con trato cercano y cálido.",
+    "Equipamiento digital de última generación con entrega rápida de informes.",
+    "Coordinación directa con ginecología, obstetricia y otras especialidades del centro.",
+    "Turnos por WhatsApp para agilizar la gestión y evitar esperas innecesarias.",
+];
+
+const faqItems: FaqItem[] = [
+    {
+        question: "¿Qué estudios ecográficos puedo hacer en CeFEM?",
+        answer: "Realizamos ecografías generales, obstétricas, ginecológicas, mamarias, renales y doppler color. Consultanos si necesitás un estudio específico.",
+    },
+    {
+        question: "¿Cuánto demora el estudio y cómo recibo los resultados?",
+        answer: "La mayoría de las ecografías dura entre 15 y 30 minutos. Entregamos un informe digital o impreso en el día, acompañado por imágenes y recomendaciones médicas.",
+    },
+    {
+        question: "¿Atienden con obras sociales para ecografías?",
+        answer: "Sí, trabajamos con diferentes coberturas y también ofrecemos tarifas particulares. Escribinos por WhatsApp para validar tu obra social o coordinar formas de pago.",
+    },
+];
+
+const ctaContent = {
+    eyebrow: "RESERVÁ TU ESTUDIO",
+    title: "Coordiná tu ecografía en Las Rosas",
+    description: "Escribinos por WhatsApp y recibí asesoramiento para elegir el tipo de ecografía que necesitás y conocer la preparación adecuada.",
+    button: {
+        text: "Solicitar turno por WhatsApp",
+        link: "https://wa.me/5493471341461",
+        variant: "primary" as const,
+        target: "_blank" as const,
+    },
+};
+---
+
+<Layout
+    title="Ecografías en Las Rosas con Doppler y Obstétricas | CeFEM"
+    description="Ecografías generales, obstétricas, doppler y ginecológicas en CeFEM Las Rosas. Turnos rápidos, informes confiables y especialistas en diagnóstico por imágenes."
+    canonicalUrl="/ecografias-las-rosas/"
+>
+    <InnerHero content={heroContent} />
+
+    <section class="py-16 md:py-24 bg-background">
+        <div class="site-container mx-auto px-4 grid gap-12 lg:grid-cols-[3fr_2fr] items-start">
+            <div>
+                <h2 class="text-3xl md:text-4xl font-semibold text-primary mb-6">Estudios ecográficos realizados en CeFEM</h2>
+                <p class="text-lg text-body-base mb-8">
+                    Nuestro servicio de diagnóstico por imágenes combina equipos digitales de alta definición con médicos especialistas que interpretan cada estudio con precisión. Coordinamos los turnos con las diferentes áreas del centro para brindarte un seguimiento integral y sin traslados innecesarios.
+                </p>
+                <div class="grid gap-6 md:grid-cols-2">
+                    {examSections.map((item) => (
+                        <article class="p-6 rounded-xl border border-primary/30 bg-white shadow-sm">
+                            <h3 class="text-xl font-semibold text-primary mb-3">{item.title}</h3>
+                            <p class="text-body-base leading-relaxed">{item.description}</p>
+                        </article>
+                    ))}
+                </div>
+            </div>
+            <aside class="p-6 bg-primary/10 border border-primary/20 rounded-2xl">
+                <h3 class="text-2xl font-semibold text-primary mb-4">Preparación para tu turno</h3>
+                <ul class="space-y-3 text-body-base">
+                    {preparationTips.map((tip) => (
+                        <li class="flex items-start gap-3">
+                            <span class="mt-1 inline-flex h-2.5 w-2.5 rounded-full bg-primary"></span>
+                            <span>{tip}</span>
+                        </li>
+                    ))}
+                </ul>
+            </aside>
+        </div>
+    </section>
+
+    <section class="py-16 md:py-20 bg-background-alt">
+        <div class="site-container mx-auto px-4">
+            <div class="max-w-3xl mb-10">
+                <h2 class="text-3xl md:text-4xl font-semibold mb-4">¿Por qué elegir CeFEM para tus ecografías?</h2>
+                <p class="text-lg text-body-base">
+                    Somos el único centro de Las Rosas que integra diagnóstico por imágenes con ginecología, obstetricia, pediatría y clínica médica. Eso nos permite compartir resultados de forma inmediata, coordinar interconsultas y acompañarte en cada etapa del tratamiento.
+                </p>
+            </div>
+            <div class="grid gap-6 md:grid-cols-2">
+                {differentiators.map((value) => (
+                    <div class="p-6 rounded-xl bg-white border border-background-light shadow-sm">
+                        <p class="text-body-base text-lg">{value}</p>
+                    </div>
+                ))}
+            </div>
+        </div>
+    </section>
+
+    <Faqs
+        content={{
+            eyebrow: "PREGUNTAS FRECUENTES",
+            title: "Consultas comunes sobre ecografías en CeFEM",
+            description: "Respondemos las dudas más habituales para que llegues preparado a tu estudio y aproveches al máximo la consulta.",
+            faqs: faqItems,
+        }}
+        background="base"
+        paddingTop="large"
+        paddingBottom="large"
+    />
+
+    <CtaBanner content={ctaContent} variant="contained" background="dark" paddingTop="large" paddingBottom="large" />
+</Layout>

--- a/src/pages/ginecologia/index.astro
+++ b/src/pages/ginecologia/index.astro
@@ -1,0 +1,121 @@
+---
+import Layout from "@layouts/Layout.astro";
+import InnerHero from "@components/sections/InnerHero.astro";
+import CtaBanner from "@components/sections/CtaBanner.astro";
+import Faqs from "@components/sections/Faqs.astro";
+import type { FaqItem } from "@data/faqs";
+import heroImage from "../../assets/images/blog-hero-2.jpg";
+
+const heroContent = {
+    title: "Ginecología y Obstetricia en Las Rosas",
+    description: "Controles preventivos, seguimiento del embarazo y acompañamiento integral de la salud femenina en CeFEM.",
+    imageAlt: "Consulta de ginecología en CeFEM Las Rosas",
+    backgroundImage: heroImage,
+    overlayOpacity: 0.35,
+};
+
+const careHighlights = [
+    "Consultas ginecológicas de rutina, papanicolau y colposcopía",
+    "Control preconcepcional y planificación familiar",
+    "Seguimiento del embarazo con ecografías en el mismo centro",
+    "Menopausia y climaterio: tratamiento de síntomas y controles complementarios",
+];
+
+const services = [
+    {
+        title: "Prevención y controles anuales",
+        description: "Realizamos chequeos completos con papanicolau, exámenes clínicos mamarios y estudios complementarios según la edad de cada paciente.",
+    },
+    {
+        title: "Salud sexual y planificación",
+        description: "Brindamos asesoramiento en anticoncepción, colocación de DIU, implantes subdérmicos y acompañamiento en decisiones reproductivas informadas.",
+    },
+    {
+        title: "Embarazo cuidado",
+        description: "Acompañamos cada trimestre con ecografías obstétricas, laboratorio y coordinación con nutrición, clínica médica y pediatría.",
+    },
+    {
+        title: "Atención de patologías",
+        description: "Tratamos infecciones ginecológicas, trastornos hormonales, dolores pélvicos y realizamos controles postquirúrgicos.",
+    },
+];
+
+const faqItems: FaqItem[] = [
+    {
+        question: "¿Cada cuánto debo realizarme un control ginecológico?",
+        answer: "Recomendamos un chequeo anual, incluso si no presentás síntomas. Nos permite detectar a tiempo cambios en el cuello uterino, mamas y hormonas.",
+    },
+    {
+        question: "¿Puedo coordinar estudios en el mismo turno?",
+        answer: "Sí. Integramos consultorio ginecológico con el servicio de ecografías y laboratorio cercano para que resuelvas todo en una sola visita.",
+    },
+    {
+        question: "¿Atienden embarazos de alto riesgo?",
+        answer: "Trabajamos en equipo con obstetras y especialistas externos. Si tu embarazo requiere seguimiento específico, articulamos interconsultas y controles doppler.",
+    },
+];
+
+const ctaContent = {
+    eyebrow: "CUIDADO INTEGRAL",
+    title: "Agendá tu consulta ginecológica",
+    description: "Solicitá un turno para controles preventivos, asesoramiento anticonceptivo o seguimiento del embarazo en CeFEM Las Rosas.",
+    button: {
+        text: "Solicitar turno por WhatsApp",
+        link: "https://wa.me/5493471341461",
+        variant: "primary" as const,
+        target: "_blank" as const,
+    },
+};
+---
+
+<Layout
+    title="Ginecología y Obstetricia en Las Rosas | CeFEM"
+    description="Consultas ginecológicas, planificación familiar y seguimiento del embarazo en CeFEM Las Rosas. Equipo médico cercano y ecografías en el mismo centro."
+    canonicalUrl="/ginecologia/"
+>
+    <InnerHero content={heroContent} />
+
+    <section class="py-16 md:py-20 bg-background">
+        <div class="site-container mx-auto px-4 grid gap-10 lg:grid-cols-[3fr_2fr] items-start">
+            <div>
+                <h2 class="text-3xl md:text-4xl font-semibold text-primary mb-6">Acompañamiento ginecológico en cada etapa</h2>
+                <p class="text-lg text-body-base mb-6">
+                    Nuestros consultorios están diseñados para brindar contención y privacidad. Escuchamos tus inquietudes, explicamos cada estudio y elaboramos planes personalizados, ya sea para controles preventivos, planificación familiar o seguimiento del embarazo.
+                </p>
+                <div class="grid gap-6 md:grid-cols-2">
+                    {services.map((service) => (
+                        <article class="p-6 rounded-xl border border-primary/20 bg-white shadow-sm">
+                            <h3 class="text-xl font-semibold text-primary mb-3">{service.title}</h3>
+                            <p class="text-body-base leading-relaxed">{service.description}</p>
+                        </article>
+                    ))}
+                </div>
+            </div>
+            <aside class="p-6 rounded-2xl bg-primary/10 border border-primary/20">
+                <h3 class="text-2xl font-semibold text-primary mb-4">Cómo preparamos tu consulta</h3>
+                <ul class="space-y-3 text-body-base">
+                    {careHighlights.map((item) => (
+                        <li class="flex items-start gap-3">
+                            <span class="mt-1 inline-flex h-2.5 w-2.5 rounded-full bg-primary"></span>
+                            <span>{item}</span>
+                        </li>
+                    ))}
+                </ul>
+            </aside>
+        </div>
+    </section>
+
+    <Faqs
+        content={{
+            eyebrow: "PREGUNTAS FRECUENTES",
+            title: "Consultas habituales de ginecología",
+            description: "Respondemos las dudas que más escuchamos en consultorio para que llegues tranquila a tu turno.",
+            faqs: faqItems,
+        }}
+        background="base"
+        paddingTop="large"
+        paddingBottom="large"
+    />
+
+    <CtaBanner content={ctaContent} variant="contained" background="dark" paddingTop="large" paddingBottom="large" />
+</Layout>

--- a/src/pages/nutricion/index.astro
+++ b/src/pages/nutricion/index.astro
@@ -1,0 +1,121 @@
+---
+import Layout from "@layouts/Layout.astro";
+import InnerHero from "@components/sections/InnerHero.astro";
+import CtaBanner from "@components/sections/CtaBanner.astro";
+import Faqs from "@components/sections/Faqs.astro";
+import type { FaqItem } from "@data/faqs";
+import heroImage from "../../assets/images/blog-hero-2.jpg";
+
+const heroContent = {
+    title: "Nutrición y hábitos saludables en Las Rosas",
+    description: "Planes personalizados para todas las etapas de la vida: control de peso, patologías crónicas y nutrición en el embarazo.",
+    imageAlt: "Consulta de nutrición en CeFEM Las Rosas",
+    backgroundImage: heroImage,
+    overlayOpacity: 0.35,
+};
+
+const nutritionApproach = [
+    "Evaluación inicial completa: historia clínica, hábitos alimentarios y antropometría",
+    "Planes de alimentación equilibrados y adaptados a la rutina de cada paciente",
+    "Educación nutricional para toda la familia y acompañamiento semanal o quincenal",
+    "Coordinación con ginecología, pediatría y clínica médica para tratamientos integrales",
+];
+
+const programAreas = [
+    {
+        title: "Control de peso saludable",
+        description: "Diseñamos planes graduales que priorizan la salud metabólica, la relación con la comida y el mantenimiento a largo plazo.",
+    },
+    {
+        title: "Nutrición en el embarazo y lactancia",
+        description: "Acompañamos las demandas nutricionales de la madre y el bebé, coordinando con obstetricia y ecografías para un control completo.",
+    },
+    {
+        title: "Patologías crónicas",
+        description: "Planes para diabetes, hipertensión, colesterol elevado, enfermedad celíaca y trastornos gastrointestinales, con seguimiento interdisciplinario.",
+    },
+    {
+        title: "Nutrición infantil y deportiva",
+        description: "Orientamos a familias con niños selectivos, adolescentes deportistas y pacientes que requieren soporte nutricional específico.",
+    },
+];
+
+const faqItems: FaqItem[] = [
+    {
+        question: "¿Cada cuánto se realizan los controles nutricionales?",
+        answer: "Depende del objetivo. En planes de descenso de peso trabajamos con controles semanales o quincenales, mientras que en patologías crónicas se coordinan visitas mensuales.",
+    },
+    {
+        question: "¿Debo llevar estudios o análisis de laboratorio?",
+        answer: "Si tenés análisis recientes ayudan a personalizar el plan. También podemos solicitar estudios específicos y coordinarlos con el resto de las especialidades de CeFEM.",
+    },
+    {
+        question: "¿Trabajan con planes para niños y adolescentes?",
+        answer: "Sí. Diseñamos propuestas lúdicas y educativas que involucran a toda la familia para generar hábitos duraderos y saludables.",
+    },
+];
+
+const ctaContent = {
+    eyebrow: "BIENESTAR INTEGRAL",
+    title: "Solicitá tu turno con nutrición",
+    description: "Coordiná una consulta para mejorar tus hábitos, acompañar tratamientos médicos o preparar tu embarazo con el equipo de CeFEM.",
+    button: {
+        text: "Escribir por WhatsApp",
+        link: "https://wa.me/5493471341461",
+        variant: "primary" as const,
+        target: "_blank" as const,
+    },
+};
+---
+
+<Layout
+    title="Nutrición en Las Rosas con planes personalizados | CeFEM"
+    description="Consultas de nutrición clínica, embarazo, deporte y patologías crónicas en CeFEM Las Rosas. Planes alimentarios sostenibles y coordinación con otras especialidades."
+    canonicalUrl="/nutricion/"
+>
+    <InnerHero content={heroContent} />
+
+    <section class="py-16 md:py-20 bg-background">
+        <div class="site-container mx-auto px-4 grid gap-10 lg:grid-cols-[3fr_2fr] items-start">
+            <div>
+                <h2 class="text-3xl md:text-4xl font-semibold text-primary mb-6">Planes de alimentación adaptados a tu realidad</h2>
+                <p class="text-lg text-body-base mb-6">
+                    El enfoque nutricional de CeFEM se basa en escuchar tus necesidades, entender tu rutina y acompañarte con herramientas prácticas. Creamos estrategias alcanzables que mejoran tu bienestar, sin dietas extremas ni restricciones innecesarias.
+                </p>
+                <div class="grid gap-6 md:grid-cols-2">
+                    {programAreas.map((area) => (
+                        <article class="p-6 rounded-xl border border-primary/20 bg-white shadow-sm">
+                            <h3 class="text-xl font-semibold text-primary mb-3">{area.title}</h3>
+                            <p class="text-body-base leading-relaxed">{area.description}</p>
+                        </article>
+                    ))}
+                </div>
+            </div>
+            <aside class="p-6 rounded-2xl bg-primary/10 border border-primary/20">
+                <h3 class="text-2xl font-semibold text-primary mb-4">Cómo trabajamos en cada sesión</h3>
+                <ul class="space-y-3 text-body-base">
+                    {nutritionApproach.map((item) => (
+                        <li class="flex items-start gap-3">
+                            <span class="mt-1 inline-flex h-2.5 w-2.5 rounded-full bg-primary"></span>
+                            <span>{item}</span>
+                        </li>
+                    ))}
+                </ul>
+            </aside>
+        </div>
+    </section>
+
+    <Faqs
+        content={{
+            eyebrow: "PREGUNTAS FRECUENTES",
+            title: "Consultas sobre el servicio de nutrición",
+            description: "Resolvemos dudas sobre la frecuencia de las consultas, los estudios necesarios y el acompañamiento familiar.",
+            faqs: faqItems,
+        }}
+        background="base"
+        paddingTop="large"
+        paddingBottom="large"
+    />
+
+    <CtaBanner content={ctaContent} variant="contained" background="dark" paddingTop="large" paddingBottom="large" />
+</Layout>

--- a/src/pages/pediatria/index.astro
+++ b/src/pages/pediatria/index.astro
@@ -1,0 +1,121 @@
+---
+import Layout from "@layouts/Layout.astro";
+import InnerHero from "@components/sections/InnerHero.astro";
+import CtaBanner from "@components/sections/CtaBanner.astro";
+import Faqs from "@components/sections/Faqs.astro";
+import type { FaqItem } from "@data/faqs";
+import heroImage from "../../assets/images/blog-hero-2.jpg";
+
+const heroContent = {
+    title: "Pediatría en Las Rosas – CeFEM",
+    description: "Consultas de control, niño sano, vacunación y seguimiento integral del desarrollo infantil.",
+    imageAlt: "Consulta pediátrica en CeFEM Las Rosas",
+    backgroundImage: heroImage,
+    overlayOpacity: 0.35,
+};
+
+const visitHighlights = [
+    "Controles del recién nacido y del niño sano",
+    "Seguimiento del crecimiento y desarrollo",
+    "Atención de enfermedades respiratorias y digestivas",
+    "Orientación en alimentación, sueño y hábitos saludables",
+];
+
+const serviceBlocks = [
+    {
+        title: "Consultas de control",
+        description: "Chequeamos peso, talla, perímetro cefálico y signos vitales en cada etapa. Orientamos sobre alimentación complementaria, lactancia y hábitos familiares.",
+    },
+    {
+        title: "Atención de urgencias leves",
+        description: "Asistimos fiebre, dolor abdominal, alergias y cuadros respiratorios con seguimiento cercano y derivación cuando es necesario.",
+    },
+    {
+        title: "Plan de vacunación",
+        description: "Te recordamos las vacunas obligatorias y optativas, coordinamos con los vacunatorios locales y registramos cada dosis en la historia clínica.",
+    },
+    {
+        title: "Trabajo en equipo",
+        description: "Articulamos con traumatología, nutrición y fonoaudiología para abordar integralmente el desarrollo infantil y las patologías crónicas.",
+    },
+];
+
+const faqItems: FaqItem[] = [
+    {
+        question: "¿Con qué frecuencia debo traer a mi hijo al pediatra?",
+        answer: "Durante el primer año sugerimos controles mensuales o bimestrales. Luego, un control anual permite asegurar un crecimiento saludable y detectar signos de alerta.",
+    },
+    {
+        question: "¿Atienden urgencias fuera del horario habitual?",
+        answer: "Coordinamos derivaciones y seguimiento con guardias locales. Ante síntomas agudos, escribinos por WhatsApp para que el pediatra de CeFEM te guíe con los pasos a seguir.",
+    },
+    {
+        question: "¿Puedo coordinar estudios complementarios en CeFEM?",
+        answer: "Sí. Contamos con servicio de ecografías, laboratorio cercano y especialistas de otras áreas para brindar diagnósticos completos en menos tiempo.",
+    },
+];
+
+const ctaContent = {
+    eyebrow: "NIÑOS CUIDADOS",
+    title: "Reservá un turno de pediatría",
+    description: "Coordiná una consulta para control de niño sano, dudas sobre alimentación o seguimiento de enfermedades crónicas.",
+    button: {
+        text: "Escribir por WhatsApp",
+        link: "https://wa.me/5493471341461",
+        variant: "primary" as const,
+        target: "_blank" as const,
+    },
+};
+---
+
+<Layout
+    title="Pediatría en Las Rosas para controles y urgencias leves | CeFEM"
+    description="Consultas pediátricas, control del niño sano, vacunación y asesoramiento a familias en CeFEM Las Rosas. Turnos rápidos por WhatsApp."
+    canonicalUrl="/pediatria/"
+>
+    <InnerHero content={heroContent} />
+
+    <section class="py-16 md:py-20 bg-background">
+        <div class="site-container mx-auto px-4 grid gap-10 lg:grid-cols-[3fr_2fr] items-start">
+            <div>
+                <h2 class="text-3xl md:text-4xl font-semibold text-primary mb-6">Atención pediátrica cercana y constante</h2>
+                <p class="text-lg text-body-base mb-6">
+                    Cuidamos la salud de bebés, niños y adolescentes con una mirada integral. Construimos un vínculo de confianza con cada familia para acompañar dudas cotidianas, enfermedades frecuentes y la transición hacia la adolescencia.
+                </p>
+                <div class="grid gap-6 md:grid-cols-2">
+                    {serviceBlocks.map((block) => (
+                        <article class="p-6 rounded-xl border border-primary/20 bg-white shadow-sm">
+                            <h3 class="text-xl font-semibold text-primary mb-3">{block.title}</h3>
+                            <p class="text-body-base leading-relaxed">{block.description}</p>
+                        </article>
+                    ))}
+                </div>
+            </div>
+            <aside class="p-6 rounded-2xl bg-primary/10 border border-primary/20">
+                <h3 class="text-2xl font-semibold text-primary mb-4">Durante la consulta</h3>
+                <ul class="space-y-3 text-body-base">
+                    {visitHighlights.map((item) => (
+                        <li class="flex items-start gap-3">
+                            <span class="mt-1 inline-flex h-2.5 w-2.5 rounded-full bg-primary"></span>
+                            <span>{item}</span>
+                        </li>
+                    ))}
+                </ul>
+            </aside>
+        </div>
+    </section>
+
+    <Faqs
+        content={{
+            eyebrow: "PREGUNTAS FRECUENTES",
+            title: "Consultas pediátricas habituales",
+            description: "Respondemos dudas sobre turnos, controles y manejo de síntomas para que te sientas acompañado en todo momento.",
+            faqs: faqItems,
+        }}
+        background="base"
+        paddingTop="large"
+        paddingBottom="large"
+    />
+
+    <CtaBanner content={ctaContent} variant="contained" background="dark" paddingTop="large" paddingBottom="large" />
+</Layout>


### PR DESCRIPTION
Resumen

agregar páginas de aterrizaje dedicadas para ecografías, ginecología, pediatría y nutrición con textos localizados, llamados a la acción (CTAs) y preguntas frecuentes (FAQs)

actualizar la configuración del sitio y los menús para que apunten al dominio canónico https://www.cefem.ar/
 y a las nuevas URLs de servicios

reemplazar los enlaces de demostración obsoletos para que la navegación interna ya no apunte a rutas faltantes como /centro o /equipo